### PR TITLE
check for collection presence before throwing improper syntax error

### DIFF
--- a/app/models/inputs/effective_select/input.rb
+++ b/app/models/inputs/effective_select/input.rb
@@ -41,7 +41,7 @@ module Inputs
           collection = options.delete(:collection) || []
           grouped = collection[0].kind_of?(Array) && collection[0][0].kind_of?(String) && collection[0][1].respond_to?(:to_a) && (collection[0][1] != nil) # Array or ActiveRecord_Relation
 
-          if options[:grouped] && !grouped
+          if options[:grouped] && !grouped && collection.present?
             raise "Grouped collection expecting a Hash {'Posts' => Post.all, 'Events' => Event.all} or a Hash {'Posts' => [['Post A', 1], ['Post B', 2]], 'Events' => [['Event A', 1], ['Event B', 2]]}"
           end
 


### PR DESCRIPTION
I'm seeing this error while using effective_datatables and a polymorphic association, `purchasable`.

The model:

``` ruby
class TokenTransaction < ActiveRecord::Base
  belongs_to :purchasable, polymorphic: true
  ...
end
```

The datatable:

``` ruby
class Effective::Datatables::TokenTransactions < Effective::Datatable
  datatable do
    ...
    table_column :purchasable
    ...
  end

  def collection
    TokenTransaction.all
  end
end
```

I've got exactly one TokenTransaction record which has an associated purchasable object.

I get an error page on effective_form_inputs master which is fixed here.

Here's the select box:
![screen shot 2016-01-08 at 11 07 44 am](https://cloud.githubusercontent.com/assets/1091338/12205653/33a10828-b5f9-11e5-9555-042dfed63a2a.png)
![screen shot 2016-01-08 at 11 14 12 am](https://cloud.githubusercontent.com/assets/1091338/12205659/37426a58-b5f9-11e5-8986-37d0bf363e39.png)
